### PR TITLE
Relay Discovery and unspecific address dialing

### DIFF
--- a/dial.go
+++ b/dial.go
@@ -3,6 +3,7 @@ package relay
 import (
 	"context"
 	"fmt"
+	"math/rand"
 
 	pb "github.com/libp2p/go-libp2p-circuit/pb"
 
@@ -70,6 +71,12 @@ func (d *RelayDialer) tryDialRelays(ctx context.Context, dinfo pstore.PeerInfo) 
 		relays = append(relays, p)
 	}
 	d.mx.Unlock()
+
+	// shuffle list of relays, avoid overloading a specific relay
+	for i := range relays {
+		j := rand.Intn(i + 1)
+		relays[i], relays[j] = relays[j], relays[i]
+	}
 
 	for _, relay := range relays {
 		if len(d.host.Network().ConnsToPeer(relay)) == 0 {

--- a/dial.go
+++ b/dial.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"fmt"
 
+	pb "github.com/libp2p/go-libp2p-circuit/pb"
+
+	peer "github.com/libp2p/go-libp2p-peer"
 	pstore "github.com/libp2p/go-libp2p-peerstore"
 	tpt "github.com/libp2p/go-libp2p-transport"
 	ma "github.com/multiformats/go-multiaddr"
@@ -42,17 +45,45 @@ func (d *RelayDialer) DialContext(ctx context.Context, a ma.Multiaddr) (tpt.Conn
 		}
 	}
 
-	rinfo, err := pstore.InfoFromP2pAddr(relayaddr)
-	if err != nil {
-		return nil, err
-	}
-
 	dinfo, err := pstore.InfoFromP2pAddr(destaddr)
 	if err != nil {
 		return nil, err
 	}
 
+	if len(relayaddr.Bytes()) == 0 {
+		// unspecific relay address, try dialing using known hop relays
+		return d.tryDialRelays(ctx, *dinfo)
+	}
+
+	rinfo, err := pstore.InfoFromP2pAddr(relayaddr)
+	if err != nil {
+		return nil, err
+	}
+
 	return d.Relay().DialPeer(ctx, *rinfo, *dinfo)
+}
+
+func (d *RelayDialer) tryDialRelays(ctx context.Context, dinfo pstore.PeerInfo) (tpt.Conn, error) {
+	var relays []peer.ID
+	d.mx.Lock()
+	for p := range d.relays {
+		relays = append(relays, p)
+	}
+	d.mx.Unlock()
+
+	for _, relay := range relays {
+		rctx, cancel := context.WithTimeout(ctx, HopConnectTimeout)
+		c, err := d.Relay().DialPeer(rctx, pstore.PeerInfo{ID: relay}, dinfo)
+		cancel()
+
+		if err == nil {
+			return c, nil
+		}
+
+		log.Debugf("Error opening relay connection to %s: %s", dinfo.ID, err.Error())
+	}
+
+	return nil, RelayError{pb.CircuitRelay_HOP_NO_CONN_TO_DST}
 }
 
 func (d *RelayDialer) Matches(a ma.Multiaddr) bool {

--- a/dial.go
+++ b/dial.go
@@ -72,6 +72,10 @@ func (d *RelayDialer) tryDialRelays(ctx context.Context, dinfo pstore.PeerInfo) 
 	d.mx.Unlock()
 
 	for _, relay := range relays {
+		if len(d.host.Network().ConnsToPeer(relay)) == 0 {
+			continue
+		}
+
 		rctx, cancel := context.WithTimeout(ctx, HopConnectTimeout)
 		c, err := d.Relay().DialPeer(rctx, pstore.PeerInfo{ID: relay}, dinfo)
 		cancel()

--- a/notify.go
+++ b/notify.go
@@ -51,8 +51,4 @@ func (n *RelayNotifiee) Connected(s inet.Network, c inet.Conn) {
 	}(c.RemotePeer())
 }
 
-func (n *RelayNotifiee) Disconnected(s inet.Network, c inet.Conn) {
-	n.mx.Lock()
-	delete(n.relays, c.RemotePeer())
-	n.mx.Unlock()
-}
+func (n *RelayNotifiee) Disconnected(s inet.Network, c inet.Conn) {}

--- a/notify.go
+++ b/notify.go
@@ -1,0 +1,58 @@
+package relay
+
+import (
+	"context"
+	"time"
+
+	inet "github.com/libp2p/go-libp2p-net"
+	peer "github.com/libp2p/go-libp2p-peer"
+	ma "github.com/multiformats/go-multiaddr"
+)
+
+var _ inet.Notifiee = (*RelayNotifiee)(nil)
+
+type RelayNotifiee Relay
+
+func (r *Relay) Notifiee() inet.Notifiee {
+	return (*RelayNotifiee)(r)
+}
+
+func (n *RelayNotifiee) Relay() *Relay {
+	return (*Relay)(n)
+}
+
+func (n *RelayNotifiee) Listen(net inet.Network, a ma.Multiaddr)      {}
+func (n *RelayNotifiee) ListenClose(net inet.Network, a ma.Multiaddr) {}
+func (n *RelayNotifiee) OpenedStream(net inet.Network, s inet.Stream) {}
+func (n *RelayNotifiee) ClosedStream(net inet.Network, s inet.Stream) {}
+
+func (n *RelayNotifiee) Connected(s inet.Network, c inet.Conn) {
+	if n.Relay().Transport().Matches(c.RemoteMultiaddr()) {
+		return
+	}
+
+	go func(id peer.ID) {
+		ctx, cancel := context.WithTimeout(n.ctx, time.Second)
+		defer cancel()
+
+		canhop, err := n.Relay().CanHop(ctx, id)
+
+		if err != nil {
+			log.Debugf("Error testing relay hop: %s", err.Error())
+			return
+		}
+
+		if canhop {
+			log.Debugf("Discovered hop relay %s", id.Pretty())
+			n.mx.Lock()
+			n.relays[id] = struct{}{}
+			n.mx.Unlock()
+		}
+	}(c.RemotePeer())
+}
+
+func (n *RelayNotifiee) Disconnected(s inet.Network, c inet.Conn) {
+	n.mx.Lock()
+	delete(n.relays, c.RemotePeer())
+	n.mx.Unlock()
+}

--- a/relay.go
+++ b/relay.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	// "sync"
+	"sync"
 	"time"
 
 	pb "github.com/libp2p/go-libp2p-circuit/pb"
@@ -35,8 +35,8 @@ type Relay struct {
 
 	incoming chan *Conn
 
-	// relays map[peer.ID]struct{}
-	// mx     sync.Mutex
+	relays map[peer.ID]struct{}
+	mx     sync.Mutex
 }
 
 type RelayOpt int
@@ -60,7 +60,7 @@ func NewRelay(ctx context.Context, h host.Host, opts ...RelayOpt) (*Relay, error
 		ctx:      ctx,
 		self:     h.ID(),
 		incoming: make(chan *Conn),
-		// relays:   make(map[peer.ID]struct{}),
+		relays:   make(map[peer.ID]struct{}),
 	}
 
 	for _, opt := range opts {
@@ -75,7 +75,7 @@ func NewRelay(ctx context.Context, h host.Host, opts ...RelayOpt) (*Relay, error
 	}
 
 	h.SetStreamHandler(ProtoID, r.handleNewStream)
-	// h.Network().Notify(r.Notifiee())
+	h.Network().Notify(r.Notifiee())
 
 	return r, nil
 }

--- a/relay_test.go
+++ b/relay_test.go
@@ -330,3 +330,33 @@ func TestActiveRelay(t *testing.T) {
 		t.Fatal("message was incorrect:", string(data))
 	}
 }
+
+func TestRelayCanHop(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	hosts := getNetHosts(t, ctx, 2)
+
+	connect(t, hosts[0], hosts[1])
+
+	time.Sleep(10 * time.Millisecond)
+
+	r1, err := NewRelay(ctx, hosts[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = NewRelay(ctx, hosts[1], OptHop)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	canhop, err := r1.CanHop(ctx, hosts[1].ID())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !canhop {
+		t.Fatal("Relay can't hop")
+	}
+}

--- a/relay_test.go
+++ b/relay_test.go
@@ -179,6 +179,74 @@ func TestBasicRelayDial(t *testing.T) {
 	}
 }
 
+func TestUnspecificRelayDial(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	hosts := getNetHosts(t, ctx, 3)
+
+	r1, err := NewRelay(ctx, hosts[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = NewRelay(ctx, hosts[1], OptHop)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r3, err := NewRelay(ctx, hosts[2])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	connect(t, hosts[0], hosts[1])
+	connect(t, hosts[1], hosts[2])
+
+	time.Sleep(100 * time.Millisecond)
+
+	msg := []byte("relay works!")
+	go func() {
+		list := r3.Listener()
+
+		con, err := list.Accept()
+		if err != nil {
+			t.Error(err)
+			return
+		}
+
+		_, err = con.Write(msg)
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		con.Close()
+	}()
+
+	addr, err := ma.NewMultiaddr(fmt.Sprintf("/p2p-circuit/ipfs/%s", hosts[2].ID().Pretty()))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rctx, rcancel := context.WithTimeout(ctx, time.Second)
+	defer rcancel()
+
+	d := r1.Dialer()
+	con, err := d.DialContext(rctx, addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := ioutil.ReadAll(con)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(data, msg) {
+		t.Fatal("message was incorrect:", string(data))
+	}
+}
+
 func TestRelayThroughNonHop(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/transport.go
+++ b/transport.go
@@ -24,10 +24,17 @@ func init() {
 	ma.AddProtocol(Protocol)
 
 	// Add dialer transport
+	const unspecific = "/p2p-circuit/ipfs"
 	const proto = "/ipfs/p2p-circuit/ipfs"
+
 	tps := addrutil.SupportedTransportStrings
 
-	err := addrutil.AddTransport(proto)
+	err := addrutil.AddTransport(unspecific)
+	if err != nil {
+		panic(err)
+	}
+
+	err = addrutil.AddTransport(proto)
 	if err != nil {
 		panic(err)
 	}

--- a/transport_test.go
+++ b/transport_test.go
@@ -10,21 +10,19 @@ import (
 
 	. "github.com/libp2p/go-libp2p-circuit"
 
+	host "github.com/libp2p/go-libp2p-host"
 	inet "github.com/libp2p/go-libp2p-net"
 	pstore "github.com/libp2p/go-libp2p-peerstore"
 	ma "github.com/multiformats/go-multiaddr"
 )
+
+const TestProto = "test/relay-transport"
 
 func TestRelayTransport(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	hosts := getNetHosts(t, ctx, 3)
-
-	connect(t, hosts[0], hosts[1])
-	connect(t, hosts[1], hosts[2])
-
-	time.Sleep(10 * time.Millisecond)
 
 	err := AddRelayTransport(ctx, hosts[0])
 	if err != nil {
@@ -41,7 +39,10 @@ func TestRelayTransport(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	const proto = "test/relay-transport"
+	connect(t, hosts[0], hosts[1])
+	connect(t, hosts[1], hosts[2])
+
+	time.Sleep(100 * time.Millisecond)
 
 	msg := []byte("relay works!")
 	handler := func(s inet.Stream) {
@@ -52,19 +53,77 @@ func TestRelayTransport(t *testing.T) {
 		s.Close()
 	}
 
-	hosts[2].SetStreamHandler(proto, handler)
+	hosts[2].SetStreamHandler(TestProto, handler)
 
+	testFullAddressDial(t, hosts, msg)
+	testSpecificRelayDial(t, hosts, msg)
+	testUnspecificRelayDial(t, hosts, msg)
+}
+
+func testFullAddressDial(t *testing.T, hosts []host.Host, msg []byte) {
+	addr, err := ma.NewMultiaddr(fmt.Sprintf("%s/ipfs/%s/p2p-circuit/ipfs/%s", hosts[1].Addrs()[0].String(), hosts[1].ID().Pretty(), hosts[2].ID().Pretty()))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rctx, rcancel := context.WithTimeout(context.Background(), time.Second)
+	defer rcancel()
+
+	hosts[0].Peerstore().AddAddrs(hosts[2].ID(), []ma.Multiaddr{addr}, pstore.TempAddrTTL)
+
+	s, err := hosts[0].NewStream(rctx, hosts[2].ID(), TestProto)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := ioutil.ReadAll(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(data, msg) {
+		t.Fatal("message was incorrect:", string(data))
+	}
+}
+
+func testSpecificRelayDial(t *testing.T, hosts []host.Host, msg []byte) {
 	addr, err := ma.NewMultiaddr(fmt.Sprintf("/ipfs/%s/p2p-circuit/ipfs/%s", hosts[1].ID().Pretty(), hosts[2].ID().Pretty()))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	rctx, rcancel := context.WithTimeout(ctx, time.Second)
+	rctx, rcancel := context.WithTimeout(context.Background(), time.Second)
 	defer rcancel()
 
 	hosts[0].Peerstore().AddAddrs(hosts[2].ID(), []ma.Multiaddr{addr}, pstore.TempAddrTTL)
 
-	s, err := hosts[0].NewStream(rctx, hosts[2].ID(), proto)
+	s, err := hosts[0].NewStream(rctx, hosts[2].ID(), TestProto)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := ioutil.ReadAll(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(data, msg) {
+		t.Fatal("message was incorrect:", string(data))
+	}
+}
+
+func testUnspecificRelayDial(t *testing.T, hosts []host.Host, msg []byte) {
+	addr, err := ma.NewMultiaddr(fmt.Sprintf("/p2p-circuit/ipfs/%s", hosts[2].ID().Pretty()))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rctx, rcancel := context.WithTimeout(context.Background(), time.Second)
+	defer rcancel()
+
+	hosts[0].Peerstore().AddAddrs(hosts[2].ID(), []ma.Multiaddr{addr}, pstore.TempAddrTTL)
+
+	s, err := hosts[0].NewStream(rctx, hosts[2].ID(), TestProto)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/transport_test.go
+++ b/transport_test.go
@@ -18,10 +18,9 @@ import (
 
 const TestProto = "test/relay-transport"
 
-func TestRelayTransport(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+var msg = []byte("relay works!")
 
+func testSetupRelay(t *testing.T, ctx context.Context) []host.Host {
 	hosts := getNetHosts(t, ctx, 3)
 
 	err := AddRelayTransport(ctx, hosts[0])
@@ -44,7 +43,6 @@ func TestRelayTransport(t *testing.T) {
 
 	time.Sleep(100 * time.Millisecond)
 
-	msg := []byte("relay works!")
 	handler := func(s inet.Stream) {
 		_, err := s.Write(msg)
 		if err != nil {
@@ -55,18 +53,21 @@ func TestRelayTransport(t *testing.T) {
 
 	hosts[2].SetStreamHandler(TestProto, handler)
 
-	testFullAddressDial(t, hosts, msg)
-	testSpecificRelayDial(t, hosts, msg)
-	testUnspecificRelayDial(t, hosts, msg)
+	return hosts
 }
 
-func testFullAddressDial(t *testing.T, hosts []host.Host, msg []byte) {
+func TestFullAddressTransportDial(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	hosts := testSetupRelay(t, ctx)
+
 	addr, err := ma.NewMultiaddr(fmt.Sprintf("%s/ipfs/%s/p2p-circuit/ipfs/%s", hosts[1].Addrs()[0].String(), hosts[1].ID().Pretty(), hosts[2].ID().Pretty()))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	rctx, rcancel := context.WithTimeout(context.Background(), time.Second)
+	rctx, rcancel := context.WithTimeout(ctx, time.Second)
 	defer rcancel()
 
 	hosts[0].Peerstore().AddAddrs(hosts[2].ID(), []ma.Multiaddr{addr}, pstore.TempAddrTTL)
@@ -86,13 +87,18 @@ func testFullAddressDial(t *testing.T, hosts []host.Host, msg []byte) {
 	}
 }
 
-func testSpecificRelayDial(t *testing.T, hosts []host.Host, msg []byte) {
+func TestSpecificRelayTransportDial(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	hosts := testSetupRelay(t, ctx)
+
 	addr, err := ma.NewMultiaddr(fmt.Sprintf("/ipfs/%s/p2p-circuit/ipfs/%s", hosts[1].ID().Pretty(), hosts[2].ID().Pretty()))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	rctx, rcancel := context.WithTimeout(context.Background(), time.Second)
+	rctx, rcancel := context.WithTimeout(ctx, time.Second)
 	defer rcancel()
 
 	hosts[0].Peerstore().AddAddrs(hosts[2].ID(), []ma.Multiaddr{addr}, pstore.TempAddrTTL)
@@ -112,13 +118,18 @@ func testSpecificRelayDial(t *testing.T, hosts []host.Host, msg []byte) {
 	}
 }
 
-func testUnspecificRelayDial(t *testing.T, hosts []host.Host, msg []byte) {
+func TestUnspecificRelayTransportDial(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	hosts := testSetupRelay(t, ctx)
+
 	addr, err := ma.NewMultiaddr(fmt.Sprintf("/p2p-circuit/ipfs/%s", hosts[2].ID().Pretty()))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	rctx, rcancel := context.WithTimeout(context.Background(), time.Second)
+	rctx, rcancel := context.WithTimeout(ctx, time.Second)
 	defer rcancel()
 
 	hosts[0].Peerstore().AddAddrs(hosts[2].ID(), []ma.Multiaddr{addr}, pstore.TempAddrTTL)


### PR DESCRIPTION
Implements passive relay discovery and unspecific relay address dialing, as discussed in https://github.com/libp2p/go-libp2p/issues/209. 

Implementation Notes:
- Relay discovery is implemented through a Notifee, which tests CanHop for all new connections and tracks a list of known hop relays.
- Unspecific address dialing is implemented by iterating through the list of known relays and attempting to dial through them; if none of the connection attempts succeed it fails with a RelayError.