### PR TITLE
gx: update go-testutil

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-1.1.3: QmYv8PxtikjeL6AfsheUiJfoFRzKvx8hdwRf4odBWH7mQx
+1.1.4: QmbVTkb8ihJNudRL4Vf9wjxMAapWxYdehrS7XBij31AGKM

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "Qmeqtv7ASvepCpUDxysK2oP1urtEr5eMNMxbhTJYJziAGo",
+      "hash": "QmW8Rgju5JrSMHP7RDNdiwwXyenRqAbtSaPfdQKQC7ZdH6",
       "name": "go-libp2p-host",
-      "version": "1.3.17"
+      "version": "1.3.18"
     },
     {
       "author": "whyrusleeping",
@@ -74,9 +74,9 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmPVjuusqQxSZrE3e35qvnge8n7Hs7NnfkHyFdkaBkWQdB",
+      "hash": "QmZG4W8GR9FpC4z69Vab9ENtEoxKjDnTym5oa7Q3Yr7P4o",
       "name": "go-libp2p-netutil",
-      "version": "0.2.20"
+      "version": "0.2.21"
     },
     {
       "author": "whyrusleeping",
@@ -86,15 +86,15 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmRCK8YSxVuHayP3s9bpLRB5Ty7tsjAfgf16aJCNSuV7kS",
+      "hash": "QmYCDYphqhKPAfyyLQykUMYikhV9a4NhxgQarwNsbQyctu",
       "name": "go-libp2p-blankhost",
-      "version": "0.1.16"
+      "version": "0.1.17"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmW8QNRUf1nqeRxZdhGg5DVcxHMwxuuNt7AWfmDi2a8JE2",
+      "hash": "QmfGXKgqQmaPHDHPSG3Y9vCVtFZtFeRZJW7N1anXB5biRu",
       "name": "go-libp2p-swarm",
-      "version": "1.7.2"
+      "version": "1.7.3"
     },
     {
       "author": "whyrusleeping",
@@ -114,5 +114,6 @@
   "license": "MIT",
   "name": "go-libp2p-circuit",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "1.1.3"
+  "version": "1.1.4"
 }
+


### PR DESCRIPTION
Depends on:

- https://github.com/libp2p/go-libp2p-conn/pull/12
- https://github.com/libp2p/go-libp2p-connmgr/pull/3
- https://github.com/libp2p/go-libp2p-host/pull/6
- https://github.com/libp2p/go-libp2p-swarm/pull/28
- https://github.com/libp2p/go-libp2p-netutil/pull/8
- https://github.com/libp2p/go-libp2p-blankhost/pull/3


This PR with gx updates has been created using gx-workspace: https://github.com/ipfs/gx-workspace