### PR TITLE
gx: update go-cid, go-multibase, base32

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-1.1.5: QmYBGpZ3hV89RZTd3CTjjgjgcX64QnbcBS9dCqU7mCgS1n
+1.1.6: QmY8a2Zohd4Jxgj5BEfcWQtR1Q3jUsvkgMLc5sBn8nqpWS

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmW8Rgju5JrSMHP7RDNdiwwXyenRqAbtSaPfdQKQC7ZdH6",
+      "hash": "QmUwW8jMQDxXhLD2j4EfWqLEMX3MsvyWcWGvJPVDh1aTmu",
       "name": "go-libp2p-host",
-      "version": "1.3.18"
+      "version": "1.3.19"
     },
     {
       "author": "whyrusleeping",
@@ -74,9 +74,9 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmYdcTdkuCvFXLj2uejJF5aY3HWhtd8JLT4BjPxF9BNPYf",
+      "hash": "QmYTeBaLWbFKQAtVTHbxvTbKfgqrGJUupK4UwjeugownfD",
       "name": "go-libp2p-netutil",
-      "version": "0.2.22"
+      "version": "0.2.23"
     },
     {
       "author": "whyrusleeping",
@@ -86,15 +86,15 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmYCDYphqhKPAfyyLQykUMYikhV9a4NhxgQarwNsbQyctu",
+      "hash": "QmSmgF5Nnmf1Ygkv96xCmUdPk4QPx3JotTA7sqwXpoxCV2",
       "name": "go-libp2p-blankhost",
-      "version": "0.1.17"
+      "version": "0.1.18"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmVJefKHXEx28RFpmj5GeRg43AqeBH3npPwvgJ875fBPm7",
+      "hash": "QmQ8c9nscf6kxoxCoXGxuXWB4ruQ1ttfRG5gKcQbNgJvGr",
       "name": "go-libp2p-swarm",
-      "version": "1.7.4"
+      "version": "1.7.5"
     },
     {
       "author": "whyrusleeping",
@@ -114,6 +114,6 @@
   "license": "MIT",
   "name": "go-libp2p-circuit",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "1.1.5"
+  "version": "1.1.6"
 }
 


### PR DESCRIPTION
Depends on:

- https://github.com/libp2p/go-testutil/pull/12
- https://github.com/libp2p/go-libp2p-conn/pull/15
- https://github.com/libp2p/go-libp2p-connmgr/pull/5
- https://github.com/libp2p/go-libp2p-host/pull/8
- https://github.com/libp2p/go-libp2p-swarm/pull/32
- https://github.com/libp2p/go-libp2p-netutil/pull/11
- https://github.com/libp2p/go-libp2p-blankhost/pull/5


This PR with gx updates has been created using gx-workspace: https://github.com/ipfs/gx-workspace