### PR TITLE
tag 'can-hop' peers to aid in connection closing logic

### DIFF
--- a/notify.go
+++ b/notify.go
@@ -47,6 +47,7 @@ func (n *RelayNotifiee) Connected(s inet.Network, c inet.Conn) {
 			n.mx.Lock()
 			n.relays[id] = struct{}{}
 			n.mx.Unlock()
+			n.host.ConnManager().TagPeer(id, "relay-hop", 2)
 		}
 	}(c.RemotePeer())
 }


### PR DESCRIPTION
This should also probably tag relay peers with a higher value when they are actually relaying a connection for us. The logic there isnt simple, so i've punted on it for now.

