### PR TITLE
gx: update go-peerstream

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-2.0.3: QmfHWhmJSJD9RjogJdPsb7wzJbUkxpZkctHvAfvJCTAP6X
+2.0.4: Qmf7GSJ4omRJsvA9uzTqzbnVhq4RWLPzjzW4xJzUta4dKE

--- a/package.json
+++ b/package.json
@@ -74,9 +74,9 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmdzuGp4a9pahgXuBeReHdYGUzdVX3FUCwfmWVo5mQfkTi",
+      "hash": "QmQGX417WoxKxDJeHqouMEmmH4G1RCENNSzkZYHrXy3Xb3",
       "name": "go-libp2p-netutil",
-      "version": "0.3.2"
+      "version": "0.3.3"
     },
     {
       "author": "whyrusleeping",
@@ -92,9 +92,9 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmWpJ4y2vxJ6GZpPfQbpVpQxAYS3UeR6AKNbAHxw7wN3qw",
+      "hash": "QmdQFrFnPrKRQtpeHKjZ3cVNwxmGKKS2TvhJTuN9C9yduh",
       "name": "go-libp2p-swarm",
-      "version": "2.0.3"
+      "version": "2.0.5"
     },
     {
       "author": "whyrusleeping",
@@ -114,6 +114,6 @@
   "license": "MIT",
   "name": "go-libp2p-circuit",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "2.0.3"
+  "version": "2.0.4"
 }
 


### PR DESCRIPTION
Depends on:

- https://github.com/libp2p/go-libp2p-swarm/pull/39
- https://github.com/libp2p/go-libp2p-netutil/pull/13


This PR with gx updates has been created using gx-workspace: https://github.com/ipfs/gx-workspace