### PR TITLE
fix: dont error out on unknown addrs in peer info

### DIFF
--- a/util.go
+++ b/util.go
@@ -29,9 +29,8 @@ func peerToPeerInfo(p *pb.CircuitRelay_Peer) (pstore.PeerInfo, error) {
 	for i := 0; i < len(addrs); i++ {
 		a, err := ma.NewMultiaddrBytes(p.Addrs[i])
 		if err != nil {
-			return pstore.PeerInfo{}, err
+			addrs[i] = a
 		}
-		addrs[i] = a
 	}
 
 	return pstore.PeerInfo{ID: peer.ID(h), Addrs: addrs}, nil

--- a/util.go
+++ b/util.go
@@ -28,7 +28,7 @@ func peerToPeerInfo(p *pb.CircuitRelay_Peer) (pstore.PeerInfo, error) {
 	addrs := make([]ma.Multiaddr, len(p.Addrs))
 	for i := 0; i < len(addrs); i++ {
 		a, err := ma.NewMultiaddrBytes(p.Addrs[i])
-		if err != nil {
+		if err == nil {
 			addrs[i] = a
 		}
 	}


### PR DESCRIPTION
This PR tries to fix the `browser-browser-go` case reported in https://github.com/ipfs/interop/issues/16. The js circuit will send all the addrs it knows of the src and dst peers, but go will error out if it doesn't know one, since we have addrs that are valid only in some implementations, it causes this error. In this case, the websocket start addr was being sent (code 479).