### PR TITLE
fix the relay reset test again

### DIFF
--- a/relay_test.go
+++ b/relay_test.go
@@ -149,14 +149,15 @@ func TestRelayReset(t *testing.T) {
 			return
 		}
 
+		<-ready
+
 		_, err = con.Write(msg)
 		if err != nil {
 			t.Error(err)
 			return
 		}
-		<-ready
 
-		hosts[2].Close()
+		hosts[2].Network().ClosePeer(hosts[1].ID())
 	}()
 
 	rinfo := hosts[1].Peerstore().PeerInfo(hosts[1].ID())


### PR DESCRIPTION
This should be the final time I need to do this. We need to close the connection to the relay *before* closing the connection to other node.