### PR TITLE
fix: FullClose is now half-open

### DIFF
--- a/relay.go
+++ b/relay.go
@@ -163,9 +163,7 @@ func (r *Relay) CanHop(ctx context.Context, id peer.ID) (bool, error) {
 		s.Reset()
 		return false, err
 	}
-	if err := inet.FullClose(s); err != nil {
-		return false, err
-	}
+	go inet.FullClose(s)
 
 	if msg.GetType() != pb.CircuitRelay_STATUS {
 		return false, fmt.Errorf("unexpected relay response; not a status message (%d)", msg.GetType())


### PR DESCRIPTION
It seems like `FullClose` needs to be called async. This is currently breaking   https://github.com/ipfs/interop/pull/27. There are other instances of `FullClose` that are not being executed in a go routine as well, and I wonder if those should also be fixed as well?