### PR TITLE
use peer.IDFromBytes instead of parsing multihash directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,12 +73,6 @@
       "version": "3.0.9"
     },
     {
-      "author": "multiformats",
-      "hash": "QmPnFwZ2JXKnXgMw8CdBPxn7FWh6LLdjUjxV1fKHuJnkr8",
-      "name": "go-multihash",
-      "version": "1.0.8"
-    },
-    {
       "author": "steb",
       "hash": "QmefQrpDSYX6jQRtUyhcASFVBDkoAsDTPXemyxGMzA3phK",
       "name": "go-libp2p-transport-upgrader",

--- a/util.go
+++ b/util.go
@@ -12,7 +12,6 @@ import (
 	peer "github.com/libp2p/go-libp2p-peer"
 	pstore "github.com/libp2p/go-libp2p-peerstore"
 	ma "github.com/multiformats/go-multiaddr"
-	mh "github.com/multiformats/go-multihash"
 )
 
 func peerToPeerInfo(p *pb.CircuitRelay_Peer) (pstore.PeerInfo, error) {
@@ -20,7 +19,7 @@ func peerToPeerInfo(p *pb.CircuitRelay_Peer) (pstore.PeerInfo, error) {
 		return pstore.PeerInfo{}, errors.New("nil peer")
 	}
 
-	h, err := mh.Cast(p.Id)
+	id, err := peer.IDFromBytes(p.Id)
 	if err != nil {
 		return pstore.PeerInfo{}, err
 	}
@@ -33,7 +32,7 @@ func peerToPeerInfo(p *pb.CircuitRelay_Peer) (pstore.PeerInfo, error) {
 		}
 	}
 
-	return pstore.PeerInfo{ID: peer.ID(h), Addrs: addrs}, nil
+	return pstore.PeerInfo{ID: id, Addrs: addrs}, nil
 }
 
 func peerInfoToPeer(pi pstore.PeerInfo) *pb.CircuitRelay_Peer {


### PR DESCRIPTION
This is technically the "more correct" option and will make it easier to change
both peer IDs and multihash.