### PR TITLE
Change transport address to not include /p2p part

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -35,12 +35,14 @@ func (c *Conn) RemoteAddr() net.Addr {
 	}
 }
 
+// TODO: is it okay to cast c.Conn().RemotePeer() into a multiaddr? might be "user input"
 func (c *Conn) RemoteMultiaddr() ma.Multiaddr {
-	a, err := ma.NewMultiaddr(fmt.Sprintf("/ipfs/%s/p2p-circuit/ipfs/%s", c.Conn().RemotePeer().Pretty(), c.remote.ID.Pretty()))
-	if err != nil {
-		panic(err)
-	}
-	return a
+	proto := ma.ProtocolWithCode(ma.P_P2P).Name
+	peerid := c.Conn().RemotePeer().Pretty()
+	p2paddr := ma.StringCast(fmt.Sprintf("/%s/%s", proto, peerid))
+
+	circaddr := ma.Cast(ma.CodeToVarint(P_CIRCUIT))
+	return p2paddr.Encapsulate(circaddr)
 }
 
 func (c *Conn) LocalMultiaddr() ma.Multiaddr {

--- a/listen.go
+++ b/listen.go
@@ -1,7 +1,6 @@
 package relay
 
 import (
-	"fmt"
 	"net"
 
 	pb "github.com/libp2p/go-libp2p-circuit/pb"
@@ -50,11 +49,7 @@ func (l *RelayListener) Addr() net.Addr {
 }
 
 func (l *RelayListener) Multiaddr() ma.Multiaddr {
-	a, err := ma.NewMultiaddr(fmt.Sprintf("/p2p-circuit/ipfs/%s", l.self.Pretty()))
-	if err != nil {
-		panic(err)
-	}
-	return a
+	return ma.Cast(ma.CodeToVarint(P_CIRCUIT))
 }
 
 func (l *RelayListener) Close() error {

--- a/relay_test.go
+++ b/relay_test.go
@@ -204,15 +204,12 @@ func TestBasicRelayDial(t *testing.T) {
 		con.Close()
 	}()
 
-	addr, err := ma.NewMultiaddr(fmt.Sprintf("/ipfs/%s/p2p-circuit/ipfs/%s", hosts[1].ID().Pretty(), hosts[2].ID().Pretty()))
-	if err != nil {
-		t.Fatal(err)
-	}
+	addr := ma.StringCast(fmt.Sprintf("/ipfs/%s/p2p-circuit", hosts[1].ID().Pretty()))
 
 	rctx, rcancel := context.WithTimeout(ctx, time.Second)
 	defer rcancel()
 
-	con, err := r1.Dial(rctx, addr)
+	con, err := r1.Dial(rctx, addr, hosts[2].ID())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -262,15 +259,12 @@ func TestUnspecificRelayDial(t *testing.T) {
 		con.Close()
 	}()
 
-	addr, err := ma.NewMultiaddr(fmt.Sprintf("/p2p-circuit/ipfs/%s", hosts[2].ID().Pretty()))
-	if err != nil {
-		t.Fatal(err)
-	}
+	addr := ma.StringCast(fmt.Sprintf("/p2p-circuit"))
 
 	rctx, rcancel := context.WithTimeout(ctx, time.Second)
 	defer rcancel()
 
-	con, err := r1.Dial(rctx, addr)
+	con, err := r1.Dial(rctx, addr, hosts[2].ID())
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Doesn't work yet, dialing via circuit breaks when the change to `RelayListener.Multiaddr()` is included.