### PR TITLE
Preemptively close stream in CanHop

### DIFF
--- a/relay.go
+++ b/relay.go
@@ -214,13 +214,18 @@ func (r *Relay) CanHop(ctx context.Context, id peer.ID) (bool, error) {
 		return false, err
 	}
 
+	if err := wr.Close(); err != nil {
+		s.Reset()
+		return false, err
+	}
+
 	msg.Reset()
 
 	if err := rd.ReadMsg(&msg); err != nil {
 		s.Reset()
 		return false, err
 	}
-	if err := inet.FullClose(s); err != nil {
+	if err := inet.AwaitEOF(s); err != nil {
 		return false, err
 	}
 


### PR DESCRIPTION
Since we are done writing, we can close the write side of the stream
before reading the resulting status.

Closes https://github.com/libp2p/go-libp2p-circuit/issues/18