### PR TITLE
use io.CopyBuffer with explicitly allocated buffers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/libp2p/go-libp2p-circuit
 require (
 	github.com/gogo/protobuf v1.2.1
 	github.com/ipfs/go-log v0.0.1
+	github.com/libp2p/go-buffer-pool v0.0.1
 	github.com/libp2p/go-libp2p-blankhost v0.0.1
 	github.com/libp2p/go-libp2p-host v0.0.1
 	github.com/libp2p/go-libp2p-net v0.0.1

--- a/relay.go
+++ b/relay.go
@@ -376,7 +376,7 @@ func (r *Relay) handleHopStream(s inet.Stream, msg *pb.CircuitRelay) {
 	go func() {
 		defer r.rmLiveHop(src.ID, dst.ID)
 
-		count, err := io.Copy(s, bs)
+		count, err := io.CopyBuffer(s, bs, make([]byte, 4096))
 		if err != nil {
 			log.Debugf("relay copy error: %s", err)
 			// Reset both.
@@ -390,7 +390,7 @@ func (r *Relay) handleHopStream(s inet.Stream, msg *pb.CircuitRelay) {
 	}()
 
 	go func() {
-		count, err := io.Copy(bs, s)
+		count, err := io.CopyBuffer(bs, s, make([]byte, 4096))
 		if err != nil {
 			log.Debugf("relay copy error: %s", err)
 			// Reset both.

--- a/relay.go
+++ b/relay.go
@@ -41,8 +41,6 @@ type Relay struct {
 
 	incoming chan *Conn
 
-	bufPool pool.BufferPool
-
 	relays map[peer.ID]struct{}
 	mx     sync.Mutex
 
@@ -379,8 +377,8 @@ func (r *Relay) handleHopStream(s inet.Stream, msg *pb.CircuitRelay) {
 	go func() {
 		defer r.rmLiveHop(src.ID, dst.ID)
 
-		buf := r.bufPool.Get(4096)
-		defer r.bufPool.Put(buf)
+		buf := pool.Get(4096)
+		defer pool.Put(buf)
 
 		count, err := io.CopyBuffer(s, bs, buf)
 		if err != nil {
@@ -396,8 +394,8 @@ func (r *Relay) handleHopStream(s inet.Stream, msg *pb.CircuitRelay) {
 	}()
 
 	go func() {
-		buf := r.bufPool.Get(4096)
-		defer r.bufPool.Put(buf)
+		buf := pool.Get(4096)
+		defer pool.Put(buf)
 
 		count, err := io.CopyBuffer(bs, s, buf)
 		if err != nil {


### PR DESCRIPTION
`io.Copy` uses a 32KB buffer, which as pprof indicates results in significant memory usage.
This changes to using `io.CopyBuffer` directly with 4KB buffers.