### PR TITLE
use buffer pool in newDelimitedReader

### DIFF
--- a/relay.go
+++ b/relay.go
@@ -323,6 +323,7 @@ func (r *Relay) handleHopStream(s inet.Stream, msg *pb.CircuitRelay) {
 	// stop handshake
 	rd := newDelimitedReader(bs, maxMessageSize)
 	wr := newDelimitedWriter(bs)
+	defer rd.Close()
 
 	msg.Type = pb.CircuitRelay_STOP.Enum()
 

--- a/relay.go
+++ b/relay.go
@@ -170,6 +170,7 @@ func (r *Relay) DialPeer(ctx context.Context, relay pstore.PeerInfo, dest pstore
 
 	rd := newDelimitedReader(s, maxMessageSize)
 	wr := newDelimitedWriter(s)
+	defer rd.Close()
 
 	var msg pb.CircuitRelay
 
@@ -218,6 +219,7 @@ func (r *Relay) CanHop(ctx context.Context, id peer.ID) (bool, error) {
 
 	rd := newDelimitedReader(s, maxMessageSize)
 	wr := newDelimitedWriter(s)
+	defer rd.Close()
 
 	var msg pb.CircuitRelay
 
@@ -249,6 +251,7 @@ func (r *Relay) handleNewStream(s inet.Stream) {
 	log.Infof("new relay stream from: %s", s.Conn().RemotePeer())
 
 	rd := newDelimitedReader(s, maxMessageSize)
+	defer rd.Close()
 
 	var msg pb.CircuitRelay
 

--- a/util.go
+++ b/util.go
@@ -9,6 +9,7 @@ import (
 
 	ggio "github.com/gogo/protobuf/io"
 	proto "github.com/gogo/protobuf/proto"
+	pool "github.com/libp2p/go-buffer-pool"
 	peer "github.com/libp2p/go-libp2p-peer"
 	pstore "github.com/libp2p/go-libp2p-peerstore"
 	ma "github.com/multiformats/go-multiaddr"
@@ -64,7 +65,7 @@ type delimitedReader struct {
 // - messages are small (max 4k) and the length fits in a couple of bytes,
 //   so overall we have at most three reads per message.
 func newDelimitedReader(r io.Reader, maxSize int) *delimitedReader {
-	return &delimitedReader{r: r, buf: make([]byte, maxSize)}
+	return &delimitedReader{r: r, buf: pool.Get(maxSize)}
 }
 
 func (d *delimitedReader) ReadByte() (byte, error) {

--- a/util.go
+++ b/util.go
@@ -68,6 +68,13 @@ func newDelimitedReader(r io.Reader, maxSize int) *delimitedReader {
 	return &delimitedReader{r: r, buf: pool.Get(maxSize)}
 }
 
+func (d *delimitedReader) Close() {
+	if d.buf != nil {
+		pool.Put(d.buf)
+		d.buf = nil
+	}
+}
+
 func (d *delimitedReader) ReadByte() (byte, error) {
 	buf := d.buf[:1]
 	_, err := d.r.Read(buf)


### PR DESCRIPTION
instead of allocating the buffer flat, given how short-lived it is.