### PR TITLE
return the full address from conn.RemoteMultiaddr

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,3 +11,5 @@ require (
 	github.com/multiformats/go-multiaddr v0.0.4
 	github.com/multiformats/go-multiaddr-net v0.0.1
 )
+
+go 1.12

--- a/listen.go
+++ b/listen.go
@@ -50,7 +50,7 @@ func (l *RelayListener) Addr() net.Addr {
 }
 
 func (l *RelayListener) Multiaddr() ma.Multiaddr {
-	return ma.Cast(ma.CodeToVarint(P_CIRCUIT))
+	return circuitAddr
 }
 
 func (l *RelayListener) Close() error {

--- a/relay_test.go
+++ b/relay_test.go
@@ -193,7 +193,6 @@ func TestRelayReset(t *testing.T) {
 
 func TestBasicRelayDial(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 
 	hosts := getNetHosts(t, ctx, 3)
 
@@ -213,6 +212,7 @@ func TestBasicRelayDial(t *testing.T) {
 	)
 
 	defer func() {
+		cancel()
 		<-done
 		if conn1 != nil {
 			conn1.Close()

--- a/transport.go
+++ b/transport.go
@@ -20,8 +20,11 @@ var Protocol = ma.Protocol{
 	VCode: ma.CodeToVarint(P_CIRCUIT),
 }
 
+var circuitAddr ma.Multiaddr
+
 func init() {
 	ma.AddProtocol(Protocol)
+	circuitAddr = ma.Cast(Protocol.VCode)
 }
 
 var _ transport.Transport = (*RelayTransport)(nil)


### PR DESCRIPTION
I can't think of a good reason not to do this (see https://github.com/libp2p/go-libp2p/issues/723). I thought there was one but I can't remember what it was.

This also changes how we parse addresses to use `ma.SplitFunc`, avoiding some allocations.