### PR TITLE
simplify generation of reservations

### DIFF
--- a/v2/relay/relay.go
+++ b/v2/relay/relay.go
@@ -175,15 +175,12 @@ func (r *Relay) handleReserve(s network.Stream) {
 
 	log.Debugf("reserving relay slot for %s", p)
 
-	err := r.writeResponse(s, pbv2.Status_OK, r.makeReservationMsg(p, expire), r.makeLimitMsg(p))
-	if err != nil {
-		s.Reset()
+	// Delivery of the reservation might fail for a number of reasons.
+	// For example, the stream might be reset or the connection might be closed before the reservation is received.
+	// In that case, the reservation will just be garbage collected later.
+	if err := r.writeResponse(s, pbv2.Status_OK, r.makeReservationMsg(p, expire), r.makeLimitMsg(p)); err != nil {
 		log.Debugf("error writing reservation response; retracting reservation for %s", p)
-		r.mx.Lock()
-		delete(r.rsvp, p)
-		r.ipcs.RemoveReservation(p)
-		r.host.ConnManager().UntagPeer(p, "relay-reservation")
-		r.mx.Unlock()
+		s.Reset()
 	}
 }
 

--- a/v2/relay/relay.go
+++ b/v2/relay/relay.go
@@ -120,7 +120,7 @@ func (r *Relay) handleStream(s network.Stream) {
 
 	switch msg.GetType() {
 	case pbv2.HopMessage_RESERVE:
-		r.handleReserve(s, &msg)
+		r.handleReserve(s)
 
 	case pbv2.HopMessage_CONNECT:
 		r.handleConnect(s, &msg)
@@ -130,7 +130,7 @@ func (r *Relay) handleStream(s network.Stream) {
 	}
 }
 
-func (r *Relay) handleReserve(s network.Stream, msg *pbv2.HopMessage) {
+func (r *Relay) handleReserve(s network.Stream) {
 	defer s.Close()
 
 	p := s.Conn().RemotePeer()


### PR DESCRIPTION
There's no need for this difficult to reason about rollback procedure. Difficult because it happens after the mutex is unlocked, so other Go routines might already have modified the maps.

Really, the only reason why writing the response would fail is that the stream was closed / reset by the peer. In that case the reservation would not be received by the peer. However, this can also happen for a number of other reasons, e.g. when the stream is reset _after_ the response was written, if the peer disconnects before reading the message, and many others.